### PR TITLE
Unix ts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,4 @@ diesel = { version = "2.1.0", features = [
 diesel_migrations = "2.1.0"
 itertools = "0.12.0"
 spinners = "4.1.1"
+datetime = "0.5.2"

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ _Copyright © 2023 Oliver Winks_
 - [Scenario Runner](#scenario-runner)
   - [Specifying a scenario](#specifying-a-scenario)
   - [Running](#running)
+- [Requirements](#requirements)
 - [Live Dashboard](#live-dashboard)
   - [Deployment](#deployment)
 - [CLI Reference](#cli-reference)

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ Use this mode to compare your application with previous runs on a standard set o
 ### specifying a scenario
 
 ### running
+## Requirements
+Telegraf - https://www.influxdata.com/time-series-platform/telegraf/
+Node - https://nodejs.org/en
 
 ## Live Dashboard
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ pub mod scenario_runner;
 pub mod telegraf;
 
 use clap::{command, Args, Parser, Subcommand};
+use core::panic;
 use diesel::{prelude::*, SqliteConnection};
 use diesel_migrations::{embed_migrations, EmbeddedMigrations, MigrationHarness};
 use dotenv::dotenv;
@@ -19,6 +20,7 @@ use nanoid::nanoid;
 use std::{
     fs,
     path::{Path, PathBuf},
+    process::Command,
     sync::{Arc, Mutex},
     time::Duration,
 };
@@ -150,9 +152,24 @@ fn generate_scenario_summary(scenarios: Vec<String>) -> anyhow::Result<String> {
         })
         .map_err(|err| anyhow::anyhow!(format!("{}", err.to_string())))
 }
-
+fn check_requirements() {
+    //check for telegraf installation
+    let _ = Command::new("telegraf")
+        .arg("--version")
+        .output()
+        .unwrap_or_else(|_| {
+            panic!("Failed to execute 'telegraf --version' command. Is Telegraf installed?")
+        });
+    let _ = Command::new("node")
+        .arg("--version")
+        .output()
+        .unwrap_or_else(|_| {
+            panic!("Failed to execute 'node --version' command. Is Node installed?")
+        });
+}
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    check_requirements();
     dotenv().ok();
     env_logger::init();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -152,6 +152,7 @@ fn generate_scenario_summary(scenarios: Vec<String>) -> anyhow::Result<String> {
         })
         .map_err(|err| anyhow::anyhow!(format!("{}", err.to_string())))
 }
+// Check for installation dependancies to prevent running without telegraf / node installed
 fn check_requirements() {
     //check for telegraf installation
     let _ = Command::new("telegraf")
@@ -160,6 +161,7 @@ fn check_requirements() {
         .unwrap_or_else(|_| {
             panic!("Failed to execute 'telegraf --version' command. Is Telegraf installed?")
         });
+    //check for node installation
     let _ = Command::new("node")
         .arg("--version")
         .output()

--- a/src/metrics_server.rs
+++ b/src/metrics_server.rs
@@ -15,7 +15,7 @@ use axum::{
     routing::{get, post},
     Json, Router,
 };
-use chrono::NaiveDateTime;
+use chrono::DateTime;
 use diesel::{prelude::*, RunQueryDsl, SqliteConnection};
 use itertools::Itertools;
 use log::info;
@@ -35,8 +35,12 @@ async fn insert_scenario_run(
             cardamon_run_type: body.cardamon_run_type,
             cardamon_run_id: body.cardamon_run_id,
             scenario_name: body.scenario_name,
-            start_time: NaiveDateTime::from_timestamp_millis(body.start_time).unwrap(),
-            stop_time: NaiveDateTime::from_timestamp_millis(body.stop_time).unwrap(),
+            start_time: DateTime::from_timestamp_millis(body.start_time)
+                .unwrap()
+                .naive_utc(),
+            stop_time: DateTime::from_timestamp_millis(body.stop_time)
+                .unwrap()
+                .naive_utc(),
         },
     };
 
@@ -77,7 +81,7 @@ async fn insert_metrics(
                         usage_percent: fields.usage_percent,
                         usage_system: fields.usage_system,
                         usage_total: fields.usage_total,
-                        timestamp: NaiveDateTime::from_timestamp_opt(timestamp, 0).unwrap(),
+                        timestamp: DateTime::from_timestamp(timestamp, 0).unwrap().naive_utc(),
                     },
                 };
 
@@ -111,7 +115,8 @@ fn create_process_stats(
         .tuple_windows()
         .map(|(a, b)| MetricSlice {
             value: a.metrics.usage_percent,
-            dt_ms: b.metrics.timestamp.timestamp_millis() - a.metrics.timestamp.timestamp_millis(),
+            dt_ms: b.metrics.timestamp.and_utc().timestamp_millis()
+                - a.metrics.timestamp.and_utc().timestamp_millis(),
         })
         .collect::<Vec<_>>();
 


### PR DESCRIPTION
Small PR 

# Changes 

## Unix TS 
```rust
            start_time: NaiveDateTime::from_timestamp_millis(body.start_time).unwrap(),
```
Is depreciated, yet Diesel doesn't yet implement DateTime for migrations so .naive_utc is applied
```rust
            start_time: DateTime::from_timestamp_millis(body.start_time)
                .unwrap()
                .naive_utc(),
```
Ditto with 
```rust
      timestamp: NaiveDateTime::from_timestamp_opt(timestamp, 0).unwrap(),
```
Replaced with 
```rust
                        timestamp: DateTime::from_timestamp(timestamp, 0).unwrap().naive_utc(),
```

## Support for single scenario 
Running via:
```bash
RUST_LOG=info cargo run scenario --path=scenarios/one.js run
```
causes a panic due to 
```rust
                    let dir_entries = fs::read_dir(scenarios_path)?;
```
Added a file / directory check to allow for one scenario to be ran meaning:
```bash
RUST_LOG=info cargo run scenario --path=scenarios/one.js run
```
is valid and will run one scenario 

## Requirements 
Program ran without telegraf installed, I added a small function to check if telegraf/node are installed at the start.

## README.md 
Updated README to reflect requirements 

## Path required 
Make the Path for scenario runs a required argument, allows for a better UX/DX due to "prettier" nature of message


