### PR TITLE
Allow users to specify stdout and stderr redirect

### DIFF
--- a/.sqlx/query-0421a8d432383d159a96b63ea60a7d93c7396903de8958de82642e60d773c2c9.json
+++ b/.sqlx/query-0421a8d432383d159a96b63ea60a7d93c7396903de8958de82642e60d773c2c9.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "INSERT INTO scenario_iteration (run_id, scenario_name, iteration, start_time, stop_time) VALUES (?, ?, ?, ?, ?)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 5
+    },
+    "nullable": []
+  },
+  "hash": "0421a8d432383d159a96b63ea60a7d93c7396903de8958de82642e60d773c2c9"
+}

--- a/.sqlx/query-084c7814f1b0d996b64efcd021647698ecc4f49c885a7052d803d632621ec54a.json
+++ b/.sqlx/query-084c7814f1b0d996b64efcd021647698ecc4f49c885a7052d803d632621ec54a.json
@@ -1,0 +1,44 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            SELECT * \n            FROM scenario_iteration \n            WHERE scenario_name = ?1 AND run_id in (\n                SELECT run_id \n                FROM scenario_iteration \n                WHERE scenario_name = ?1 \n                GROUP BY run_id \n                ORDER BY start_time DESC\n                LIMIT ?2\n            )\n            ",
+  "describe": {
+    "columns": [
+      {
+        "name": "run_id",
+        "ordinal": 0,
+        "type_info": "Text"
+      },
+      {
+        "name": "scenario_name",
+        "ordinal": 1,
+        "type_info": "Text"
+      },
+      {
+        "name": "iteration",
+        "ordinal": 2,
+        "type_info": "Int64"
+      },
+      {
+        "name": "start_time",
+        "ordinal": 3,
+        "type_info": "Int64"
+      },
+      {
+        "name": "stop_time",
+        "ordinal": 4,
+        "type_info": "Int64"
+      }
+    ],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "084c7814f1b0d996b64efcd021647698ecc4f49c885a7052d803d632621ec54a"
+}

--- a/.sqlx/query-7a5586a4a3c8b1eb63fef5fd0a7d124f4af057cefc59ac6b4281baff52b620e3.json
+++ b/.sqlx/query-7a5586a4a3c8b1eb63fef5fd0a7d124f4af057cefc59ac6b4281baff52b620e3.json
@@ -1,0 +1,56 @@
+{
+  "db_name": "SQLite",
+  "query": "SELECT * FROM cpu_metrics WHERE run_id = ? AND timestamp BETWEEN ? AND ?",
+  "describe": {
+    "columns": [
+      {
+        "name": "run_id",
+        "ordinal": 0,
+        "type_info": "Text"
+      },
+      {
+        "name": "process_id",
+        "ordinal": 1,
+        "type_info": "Text"
+      },
+      {
+        "name": "process_name",
+        "ordinal": 2,
+        "type_info": "Text"
+      },
+      {
+        "name": "cpu_usage",
+        "ordinal": 3,
+        "type_info": "Float"
+      },
+      {
+        "name": "total_usage",
+        "ordinal": 4,
+        "type_info": "Float"
+      },
+      {
+        "name": "core_count",
+        "ordinal": 5,
+        "type_info": "Int64"
+      },
+      {
+        "name": "timestamp",
+        "ordinal": 6,
+        "type_info": "Int64"
+      }
+    ],
+    "parameters": {
+      "Right": 3
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "7a5586a4a3c8b1eb63fef5fd0a7d124f4af057cefc59ac6b4281baff52b620e3"
+}

--- a/.sqlx/query-db729d680a66ace4952f3bbabc82b2aeaeda1f47c713841effec346a5b930325.json
+++ b/.sqlx/query-db729d680a66ace4952f3bbabc82b2aeaeda1f47c713841effec346a5b930325.json
@@ -1,6 +1,6 @@
 {
   "db_name": "SQLite",
-  "query": "\n            SELECT * \n            FROM scenario_iteration \n            WHERE scenario_name = ?1 AND run_id in (\n                SELECT run_id \n                FROM scenario_iteration \n                WHERE scenario_name = ?1 \n                GROUP BY run_id \n                ORDER BY start_time ASC\n                LIMIT ?2\n            )\n            ",
+  "query": "SELECT * FROM scenario_iteration ORDER BY start_time DESC LIMIT 1",
   "describe": {
     "columns": [
       {
@@ -30,7 +30,7 @@
       }
     ],
     "parameters": {
-      "Right": 2
+      "Right": 0
     },
     "nullable": [
       false,
@@ -40,5 +40,5 @@
       false
     ]
   },
-  "hash": "4b959bb520ac8de777a1b3dfc71edca53bda85156129e4fd329959df456f342c"
+  "hash": "db729d680a66ace4952f3bbabc82b2aeaeda1f47c713841effec346a5b930325"
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,3 +47,4 @@ lazy_static = "1.4.0"
 uuid = { version = "1.8.0", features = ["v4"] }
 subprocess = "0.2.9"
 tracing-log = "0.2.0"
+shlex = "1.3.0"

--- a/cardamon.unix.toml
+++ b/cardamon.unix.toml
@@ -9,13 +9,14 @@ debug_level = "info" # Optional - defaults to "info"
 
 [[processes]]
 type = "baremetal"
-name = "test"                                      # Required
-command = "powershell while($true) { get-random }" # Required
+name = "test"                                                    # Required
+command = "bash -c \"while true; do shuf -i 0-1337 -n 1; done\"" # Required
+redirect.to = "file"
 
 [[scenarios]]
 name = "basket_10"                    # Required
 desc = "Adds ten items to the basket" # Optional 
-command = "powershell sleep 15"       # Required - commands for running scenarios
+command = "sleep 15"                  # Required - commands for running scenarios
 iterations = 2                        # Optional - defaults to 1
 processes = ["test"]                  # Required - prepend process name with `_` to ignore
 

--- a/cardamon.win.toml
+++ b/cardamon.win.toml
@@ -1,0 +1,25 @@
+debug_level = "info" # Optional - defaults to "info"
+#metrics_server_url = "http://cardamon.rootandbranch.io" # Optional - assumes local db if not specifed
+
+#[[processes]]
+#type = "docker"
+#name = "db"                      # Required - must be unique among ALL processes
+#containers = ["postgres"]        # Required
+#command = "docker compose up -d" # Required
+
+[[processes]]
+type = "baremetal"
+name = "test"                                      # Required
+command = "powershell while($true) { get-random }" # Required
+redirect.to = "null"
+
+[[scenarios]]
+name = "basket_10"                    # Required
+desc = "Adds ten items to the basket" # Optional 
+command = "powershell sleep 15"       # Required - commands for running scenarios
+iterations = 2                        # Optional - defaults to 1
+processes = ["test"]                  # Required - prepend process name with `_` to ignore
+
+[[observations]]
+name = "obs_1"            # Required
+scenarios = ["basket_10"] # Required

--- a/src/config.rs
+++ b/src/config.rs
@@ -45,11 +45,16 @@ impl Config {
     /// Some process if it can be found, None otherwise
     fn find_process(&self, proc_name: &str) -> Option<&ProcessToExecute> {
         self.processes.iter().find(|proc| match proc {
-            ProcessToExecute::BareMetal { name, command: _ } => name == proc_name,
+            ProcessToExecute::BareMetal {
+                name,
+                command: _,
+                redirect: _,
+            } => name == proc_name,
             ProcessToExecute::Docker {
                 name,
                 containers: _,
                 command: _,
+                redirect: _,
             } => name == proc_name,
         })
     }
@@ -137,6 +142,14 @@ impl Config {
     }
 }
 
+#[derive(Debug, Deserialize, PartialEq, Clone, Copy)]
+#[serde(tag = "to", rename_all = "lowercase")]
+pub enum Redirect {
+    Null,
+    Parent,
+    File,
+}
+
 #[derive(Debug, Deserialize, PartialEq)]
 pub struct Scenario {
     pub name: String,
@@ -162,11 +175,13 @@ pub enum ProcessToExecute {
     BareMetal {
         name: String,
         command: String,
+        redirect: Option<Redirect>,
     },
     Docker {
         name: String,
         containers: Vec<String>,
         command: String,
+        redirect: Option<Redirect>,
     },
 }
 
@@ -290,11 +305,16 @@ mod tests {
             .collect_processes(&scenarios_to_execute)?
             .into_iter()
             .map(|proc| match proc {
-                ProcessToExecute::BareMetal { name, command: _ } => name.as_str(),
+                ProcessToExecute::BareMetal {
+                    name,
+                    command: _,
+                    redirect: _,
+                } => name.as_str(),
                 ProcessToExecute::Docker {
                     name,
                     containers: _,
                     command: _,
+                    redirect: _,
                 } => name.as_str(),
             })
             .sorted()
@@ -335,8 +355,13 @@ mod tests {
                     name,
                     containers: _,
                     command: _,
+                    redirect: _,
                 } => name.as_str(),
-                ProcessToExecute::BareMetal { name, command: _ } => name.as_str(),
+                ProcessToExecute::BareMetal {
+                    name,
+                    command: _,
+                    redirect: _,
+                } => name.as_str(),
             })
             .sorted()
             .collect();
@@ -366,8 +391,13 @@ mod tests {
                     name,
                     containers: _,
                     command: _,
+                    redirect: _,
                 } => name.as_str(),
-                ProcessToExecute::BareMetal { name, command: _ } => name.as_str(),
+                ProcessToExecute::BareMetal {
+                    name,
+                    command: _,
+                    redirect: _,
+                } => name.as_str(),
             })
             .sorted()
             .collect();

--- a/src/data_access/scenario_iteration.rs
+++ b/src/data_access/scenario_iteration.rs
@@ -168,7 +168,7 @@ mod tests {
             .iter()
             .map(|run| run.run_id.as_str())
             .collect::<Vec<_>>();
-        assert_eq!(run_ids, vec!["1", "1", "1", "2", "2", "2"]);
+        assert_eq!(run_ids, vec!["2", "2", "2", "3", "3", "3"]);
 
         let iterations = scenario_iterations
             .iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,11 +5,11 @@ pub mod metrics;
 pub mod metrics_logger;
 
 use anyhow::{anyhow, Context};
-use config::{ExecutionPlan, ProcessToObserve, ScenarioToExecute};
+use config::{ExecutionPlan, ProcessToObserve, Redirect, ScenarioToExecute};
 use data_access::{scenario_iteration::ScenarioIteration, DataAccessService};
 use dataset::ObservationDataset;
-use std::time;
-use subprocess::{Exec, NullFile};
+use std::{fs::File, path::Path, time};
+use subprocess::{Exec, NullFile, Redirection};
 
 /// Runs the given command as a detached processes. This function does not block because the
 /// process is managed by the OS and running separately from this thread.
@@ -21,17 +21,34 @@ use subprocess::{Exec, NullFile};
 /// # Returns
 ///
 /// The PID returned by the operating system
-fn run_command_detached(command: &str) -> anyhow::Result<u32> {
+fn run_command_detached(command: &str, redirect: &Option<Redirect>) -> anyhow::Result<u32> {
+    let redirect = redirect.unwrap_or(Redirect::File);
+
+    // break command string into POSIX words
+    let words = shlex::split(command).expect("Command string is not POSIX compliant.");
+
     // split command string into command and args
-    match &command.split(' ').collect::<Vec<_>>()[..] {
+    match &words[..] {
         [command, args @ ..] => {
-            let mut exec = Exec::cmd(command);
-            for arg in args {
-                exec = exec.arg(arg);
-            }
+            let exec = Exec::cmd(command).args(args);
+            // for arg in args {
+            //     exec = exec.arg(arg);
+            // }
+            //
+
+            let exec = match redirect {
+                Redirect::Null => exec.stdout(NullFile).stderr(NullFile),
+                Redirect::Parent => exec,
+                Redirect::File => {
+                    let out_file = File::create(Path::new("./.stdout"))?;
+                    let err_file = File::create(Path::new("./.stderr"))?;
+
+                    exec.stdout(Redirection::File(out_file))
+                        .stderr(Redirection::File(err_file))
+                }
+            };
 
             exec.detached()
-                .stdout(NullFile)
                 .popen()
                 .context("Failed to spawn detached process")?
                 .pid()
@@ -57,9 +74,10 @@ fn run_process(proc: &config::ProcessToExecute) -> anyhow::Result<Vec<ProcessToO
             name: _,
             containers,
             command,
+            redirect,
         } => {
             // run the command
-            run_command_detached(command)?;
+            run_command_detached(command, redirect)?;
 
             // return the containers as vector of ProcessToObserve
             Ok(containers
@@ -68,9 +86,13 @@ fn run_process(proc: &config::ProcessToExecute) -> anyhow::Result<Vec<ProcessToO
                 .collect())
         }
 
-        config::ProcessToExecute::BareMetal { name: _, command } => {
+        config::ProcessToExecute::BareMetal {
+            name: _,
+            command,
+            redirect,
+        } => {
             // run the command
-            let pid = run_command_detached(command)?;
+            let pid = run_command_detached(command, redirect)?;
 
             // return the pid as a ProcessToObserve
             Ok(vec![ProcessToObserve::Pid(pid)])
@@ -200,7 +222,10 @@ pub async fn run<'a>(
 
 #[cfg(test)]
 mod tests {
-    use crate::{config::ProcessToExecute, metrics_logger, run_process, ProcessToObserve};
+    use crate::{
+        config::{ProcessToExecute, Redirect},
+        metrics_logger, run_process, ProcessToObserve,
+    };
     use std::time::Duration;
     use sysinfo::{Pid, System};
 
@@ -235,6 +260,53 @@ mod tests {
         let process = ProcessToExecute::BareMetal {
             name: "sleep".to_string(),
             command: "powershell sleep 20".to_string(),
+        };
+        let processes_to_observe = run_process(&process)?;
+        let stop_handle = metrics_logger::start_logging(&processes_to_observe)?;
+
+        tokio::time::sleep(Duration::from_secs(10)).await;
+
+        let metrics_log = stop_handle.stop().await?;
+
+        assert!(!metrics_log.has_errors());
+        assert!(!metrics_log.get_metrics().is_empty());
+
+        Ok(())
+    }
+
+    #[test]
+    #[cfg(target_family = "unix")]
+    fn can_run_a_bare_metal_process() -> anyhow::Result<()> {
+        let process = ProcessToExecute::BareMetal {
+            name: "sleep".to_string(),
+            command: "sleep 15".to_string(),
+            redirect: Some(Redirect::Null),
+        };
+        let processes_to_observe = run_process(&process)?;
+
+        assert_eq!(processes_to_observe.len(), 1);
+
+        match processes_to_observe.first().expect("process should exist") {
+            ProcessToObserve::Pid(pid) => {
+                let mut system = System::new();
+                system.refresh_all();
+                let proc = system.process(Pid::from_u32(*pid));
+                assert!(proc.is_some());
+            }
+
+            _ => panic!("expected to find a process id"),
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[cfg(target_family = "unix")]
+    async fn log_scenario_should_return_metrics_log_without_errors() -> anyhow::Result<()> {
+        let process = ProcessToExecute::BareMetal {
+            name: "sleep".to_string(),
+            command: "sleep 20".to_string(),
+            redirect: Some(Redirect::Null),
         };
         let processes_to_observe = run_process(&process)?;
         let stop_handle = metrics_logger::start_logging(&processes_to_observe)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use cardamon::{
     config::{self, ProcessToObserve},
     data_access::LocalDataAccessService,
@@ -66,8 +68,14 @@ async fn main() -> anyhow::Result<()> {
             let pool = create_db().await?;
             let data_access_service = LocalDataAccessService::new(pool);
 
+            // open config file
+            let path = match &args.file {
+                Some(path) => Path::new(path),
+                None => Path::new("./cardamon.toml"),
+            };
+
             // create an execution plan
-            let config = config::Config::from_path(std::path::Path::new("./cardamon.toml"))?;
+            let config = config::Config::from_path(path)?;
             let mut execution_plan = if external_only {
                 config.create_execution_plan_external_only(&name)
             } else {


### PR DESCRIPTION
- Added `redirect` property to [[processes]].
- Fixed and added missing tests for unix platform.
- Created new Allow users to specify where to redirect stdout and stderr.
- Updated .sqlx files.
- Updated cardamon config example.
- Added cardamon config for windows and unix platforms.
- Implemented `--file` option.

closes #40 